### PR TITLE
Fix async calls to console.log.

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -83,6 +83,7 @@
     capturingConsole.log = function() {
       if (this !== capturingConsole) { return; }
 
+      console.log.apply(console, arguments);
       var result = _.transform(arguments, function(result, val, i) {
         result[i] = typeof val === 'string' ? val : JSON.stringify(val);
       }, []).join(' ');


### PR DESCRIPTION
Instead of monkey patching `console.log`, we create a console wrapper
and monkey patch that, passing it as an argument to the generated
function so it will always be in scope.

We keep track of the current console wrapper so that any async calls
from previous evaluations will no longer cause output.

Closes #15.