### PR TITLE
Corrected amd-module-id => amd-module-ids (plural) flag per 6to5/6to5#190

### DIFF
--- a/docs/usage/modules.md
+++ b/docs/usage/modules.md
@@ -108,7 +108,7 @@ define(["exports", "foo"], function (exports, _foo) {
 });
 ```
 
-You can optionally specify to include the module id (using the `--amd-module-id`
+You can optionally specify to include the module id (using the `--amd-module-ids`
 argument):
 
 ```js


### PR DESCRIPTION
The flag was changed to be plural in PR 6to5/6to5#190