### PR TITLE
Fix code url on REPL on Firefox

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -31,8 +31,10 @@
   var getQuery = function() {
     var query = window.location.hash.replace(/^\#\?/, '');
     return _.transform(query ? query.split('&') : null, function(result, val) {
-      val = val.split('=');
-      result[val[0]] = decodeURIComponent('' + val[1]);
+      var equalsIndex = val.indexOf('=');
+      var name = val.substring(0, equalsIndex);
+      var value = val.substring(equalsIndex + 2);
+      result[name] = decodeURIComponent(value);
     }, {});
   };
 


### PR DESCRIPTION
When going to a REPL with code that contains `=` on Firefox, the code doesn't show properly, apparently because Firefox automatically decodes the URI components on `location.hash`.

To reproduce open this URI on Firefox:
https://6to5.org/repl/#?experimental=true&playground=true&evaluate=true&code=c%20%3D%201%3B
The code should be:
```
c = 1;
```

But the current version of the site shows:
```
c 
```