### PR TITLE
Clearer title for REPL page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -68,7 +68,7 @@ navigation:
   url: /docs/compare/
 - title: Caveats
   url: /docs/caveats/
-- title: REPL
+- title: Try it out
   url: /repl/
 - title: FAQ
   url: /docs/faq/


### PR DESCRIPTION
Just a suggestion.

I was browsing the site and thought REPL isn't the most obvious title for this page (accurate though it is).

Something along the lines of "Try it out" or "Live demo" would be more self explanatory, IMO.

Could also be moved to a separate section of the nav to stand out more, but that's a bigger change so wanted to get feedback on this first.