### PR TITLE
fix caveats link

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,7 +107,7 @@ User.prototype.sayHello = function () {
   <div class="row featurette">
     <div class="col-md-4 col-md-push-8">
       <h2>Compact</h2>
-      <p>Maps directly to the equivalent ES5 with no runtime.<a href="{{ site.baseurl }}/docs/caveats/">*</a></p>
+      <p>Maps directly to the equivalent ES5 with no runtime.<a href="{{ site.baseurl }}/docs/usage/caveats/">*</a></p>
     </div>
     <div class="col-md-4 col-md-pull-4 col-sm-6">
 {% highlight javascript %}


### PR DESCRIPTION
Your link on the homepage to the caveats documentation was broken! I went ahead and fixed it for you :kissing_cat:.