### PR TITLE
6to5 Sublime support blog post

### DIFF
--- a/_posts/2015-01-19-6to5-sublime.md
+++ b/_posts/2015-01-19-6to5-sublime.md
@@ -7,16 +7,10 @@ categories: announcements
 share_text: "6to5 Sublime support"
 ---
 
-We are pleased to announce <a href="https://github.com/6to5/6to5-sublime/" target="_blank">6to5-sublime</a>, a set of language syntax definitions for modern JavaScript with JSX extensions, as well as snippets for common React constructs (like lifecycle methods) in ES6. It's available as <a href="https://packagecontrol.io/packages/6to5" target="_blank">6to5</a> on <a href="https://packagecontrol.io" target="_blank">Package Control</a>. Eliminating barriers to ES6+ adoption is not just about having the most feature-ready transpiler – it's also about providing the right environment in which to write ES6+ JavaScript.
+We are pleased to announce [6to5-sublime](https://github.com/6to5/6to5-sublime/), a set of language syntax definitions for modern JavaScript with JSX extensions, as well as snippets for common React constructs (like lifecycle methods) in ES6. It's available as [6to5](https://packagecontrol.io/packages/6to5) on [Package Control](https://packagecontrol.io). Eliminating barriers to ES6+ adoption is not just about having the most feature-ready transpiler – it's also about providing the right environment in which to write ES6+ JavaScript.
 
-Under the hood, 6to5-sublime is based on the excellent <a href="https://github.com/Benvie/JavaScriptNext.tmLanguage" target="_blank">Benvie/JavaScriptNext.tmLanguage</a> project with JSX syntax support built on top. We've added many improvements over <a href="https://github.com/reactjs/sublime-react/">sublime-react</a>, including support for JSX namespaces and comments between JSX attributes.
+Under the hood, 6to5-sublime is based on the excellent [Benvie/JavaScriptNext.tmLanguage](https://github.com/Benvie/JavaScriptNext.tmLanguage) project with JSX syntax support built on top. We've added many improvements over [sublime-react](https://github.com/reactjs/sublime-react/), including support for JSX namespaces and comments between JSX attributes.
 
-<h3>6to5-sublime</h3>
-
-<img alt="6to5-sublime sample" src="https://raw.githubusercontent.com/6to5/6to5-sublime/956c85261e55f2b914eab90e2bb447344cfaa6bf/screenshots/6to5-sublime.png" />
-
-<h3>sublime-react</h3>
-
-<img alt="sublime-react sample" src="https://raw.githubusercontent.com/6to5/6to5-sublime/956c85261e55f2b914eab90e2bb447344cfaa6bf/screenshots/sublime-react.png" />
+![6to5-sublime-vs-sublime-react](https://raw.github.com/6to5/6to5-sublime/5cd4353/screenshots/6to5-sublime-vs-sublime-react.gif)
 
 <p class="text-right">— The 6to5 team</p>

--- a/_posts/2015-01-19-6to5-sublime.md
+++ b/_posts/2015-01-19-6to5-sublime.md
@@ -1,0 +1,22 @@
+---
+layout: post
+title:  "6to5 Sublime support"
+author: Andres Suarez
+date:   2015-01-19 10:40:00
+categories: announcements
+share_text: "6to5 Sublime support"
+---
+
+We are pleased to announce <a href="https://github.com/6to5/6to5-sublime/" target="_blank">6to5-sublime</a>, a set of language syntax definitions for modern JavaScript with JSX extensions, as well as snippets for common React constructs (like lifecycle methods) in ES6. It's available as <a href="https://packagecontrol.io/packages/6to5" target="_blank">6to5</a> on <a href="https://packagecontrol.io" target="_blank">Package Control</a>. Eliminating barriers to ES6+ adoption is not just about having the most feature-ready transpiler – it's also about providing the right environment in which to write ES6+ JavaScript.
+
+Under the hood, 6to5-sublime is based on the excellent <a href="https://github.com/Benvie/JavaScriptNext.tmLanguage" target="_blank">Benvie/JavaScriptNext.tmLanguage</a> project with JSX syntax support built on top. We've added many improvements over <a href="https://github.com/reactjs/sublime-react/">sublime-react</a>, including support for JSX namespaces and comments between JSX attributes.
+
+<h3>6to5-sublime</h3>
+
+<img alt="6to5-sublime sample" src="https://raw.githubusercontent.com/6to5/6to5-sublime/956c85261e55f2b914eab90e2bb447344cfaa6bf/screenshots/6to5-sublime.png" />
+
+<h3>sublime-react</h3>
+
+<img alt="sublime-react sample" src="https://raw.githubusercontent.com/6to5/6to5-sublime/956c85261e55f2b914eab90e2bb447344cfaa6bf/screenshots/sublime-react.png" />
+
+<p class="text-right">— The 6to5 team</p>


### PR DESCRIPTION
I was going to use the gif in the README for https://github.com/6to5/6to5-sublime/ but they're really distracting. But if others disagree, I'm cool with switching to the gif or not having the comparison images at all.