### PR TITLE
Change `print` to `console.log` in example code

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -261,7 +261,7 @@ for (var n of fibonacci) {
   // truncate the sequence at 1000
   if (n > 1000)
     break;
-  print(n);
+  console.log(n);
 }
 ```
 
@@ -309,7 +309,7 @@ for (var n of fibonacci) {
   // truncate the sequence at 1000
   if (n > 1000)
     break;
-  print(n);
+  console.log(n);
 }
 ```
 


### PR DESCRIPTION
When ran in the context of a browser, `print()` will call `window.print()` which opens a print dialog. It's very confusing pasting example code into the REPL only to have it open several print dialogs :)