### PR TITLE
Array destructuring now requires Symbol

### DIFF
--- a/docs/usage/caveats.md
+++ b/docs/usage/caveats.md
@@ -19,7 +19,7 @@ You may alternatively selectively include what you need:
 | Feature                     | Requirements                                                                          |
 | --------------------------- | ------------------------------------------------------------------------------------- |
 | Abstract References         | `Symbol`                                                                              |
-| Array destructuring         | `Array.from`                                                                          |
+| Array destructuring         | `Symbol`                                                                             |
 | Async functions, Generators | [regenerator runtime](https://github.com/facebook/regenerator/blob/master/runtime.js) |
 | Comprehensions              | `Array.from`                                                                          |
 | For Of                      | `Symbol`, `prototype[Symbol.iterator]`                                                |


### PR DESCRIPTION
This changed in this commit: https://github.com/6to5/6to5/commit/c509d06bc2d74b58b8edf38597b13bc278896c71