### PR TITLE
Cache bust resources via appended timestamp, fixes #6

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -8,7 +8,7 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
 

--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -16,4 +16,4 @@ layout: page
   </div>
 </div>
 
-<script src={{ "/scripts/docs.js" | prepend: site.baseurl }}></script>
+<script src="{{ "/scripts/docs.js" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@ User.prototype.sayHello = function () {
       <p>With a large range of <a href="{{ site.baseurl }}/docs/using-6to5/">plugins</a> and browser support.</p>
     </div>
     <div class="col-md-8 col-md-pull-4">
-      <img src="{{ site.baseurl }}/images/benefits-extensible.png" alt="Plugins and Browsers" class="featurette-image img-responsive">
+      <img src="{{ site.baseurl }}/images/benefits-extensible.png?t={{ site.time | date_to_xmlschema }}" alt="Plugins and Browsers" class="featurette-image img-responsive">
     </div>
   </div>
 
@@ -98,7 +98,7 @@ User.prototype.sayHello = function () {
       <p><strong>Source map</strong> support so you can debug your compiled code with ease.</p>
     </div>
     <div class="col-md-8">
-      <img src="{{ site.baseurl }}/images/benefits-lossless.png" alt="Lossless Sourcemaps" class="featurette-image img-responsive">
+      <img src="{{ site.baseurl }}/images/benefits-lossless.png?t={{ site.time | date_to_xmlschema }}" alt="Lossless Sourcemaps" class="featurette-image img-responsive">
     </div>
   </div>
 
@@ -160,7 +160,7 @@ User.prototype.sayHello = function () {
 
   <div class="row featurette">
     <div class="col-md-4 col-md-push-8 col-sm-6 col-sm-push-6">
-      <img src="{{ site.baseurl }}/images/uses-browsers.png" alt="Browsers" class="featurette-image img-responsive">
+      <img src="{{ site.baseurl }}/images/uses-browsers.png?t={{ site.time | date_to_xmlschema }}" alt="Browsers" class="featurette-image img-responsive">
     </div>
     <div class="col-md-8 col-md-pull-4 col-sm-6 col-sm-pull-6">
       <h2><a href="{{ site.baseurl }}/docs/using-6to5/#build-systems">Browsers</a></h2>
@@ -181,7 +181,7 @@ User.prototype.sayHello = function () {
 
   <div class="row featurette">
     <div class="col-md-4 col-sm-6">
-      <img src="{{ site.baseurl }}/images/uses-nodejs.png" alt="Node.js" class="featurette-image img-responsive">
+      <img src="{{ site.baseurl }}/images/uses-nodejs.png?t={{ site.time | date_to_xmlschema }}" alt="Node.js" class="featurette-image img-responsive">
     </div>
     <div class="col-md-8 col-sm-6">
       <h2><a href="{{ site.baseurl }}/docs/using-6to5/#nodejs">Node.js</a></h2>
@@ -198,7 +198,7 @@ User.prototype.sayHello = function () {
 
   <div class="row featurette">
     <div class="col-md-4 col-md-push-8 col-sm-6 col-sm-push-6">
-      <img src="{{ site.baseurl }}/images/uses-rails.png" alt="Rails" class="featurette-image img-responsive">
+      <img src="{{ site.baseurl }}/images/uses-rails.png?t={{ site.time | date_to_xmlschema }}" alt="Rails" class="featurette-image img-responsive">
     </div>
     <div class="col-md-8 col-md-pull-4 col-sm-6 col-sm-pull-6">
       <h2><a href="{{ site.baseurl }}/docs/using-6to5/#rails">Rails</a></h2>
@@ -217,7 +217,7 @@ User.prototype.sayHello = function () {
 
   <div class="row featurette">
     <div class="col-md-4 col-sm-6">
-      <img src="{{ site.baseurl }}/images/uses-browserify.png" alt="Browserify" class="featurette-image img-responsive">
+      <img src="{{ site.baseurl }}/images/uses-browserify.png?t={{ site.time | date_to_xmlschema }}" alt="Browserify" class="featurette-image img-responsive">
     </div>
     <div class="col-md-8 col-sm-6">
       <h2><a href="{{ site.baseurl }}/docs/using-6to5/#browserify">Browserify</a></h2>

--- a/repl.html
+++ b/repl.html
@@ -77,6 +77,6 @@ redirect_from: "/repl.html"
   <div class="to5-repl-reporter to5-repl-console"></div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.1.3/ace.js"></script>
-  <script src="{{ "/scripts/6to5.js" | prepend: site.baseurl }}"></script>
-  <script src="{{ "/scripts/repl.js" | prepend: site.baseurl }}"></script>
+  <script src="{{ "/scripts/6to5.js" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>
+  <script src="{{ "/scripts/repl.js" | prepend: site.baseurl }}?t={{ site.time | date_to_xmlschema }}"></script>
 </div>


### PR DESCRIPTION
@thejameskyle Let me know if this is roughly what you had in mind and/or if there are other resources that need to be considered.  Note that I used the date_to_xmlschema filter because it puts the timestamp in ISO8601 format, which should be URL safe.  The site.time Jekyll site variable should reflect when the Github Pages server spins up a new site after a publish.