### PR TITLE
fix null state error on initial visit

### DIFF
--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -106,11 +106,14 @@
    * 6to5 Web REPL
    */
   function REPL () {
-    var state = UriUtils.parseQuery();
+    var state = UriUtils.parseQuery() || {};
     
     if (window.localStorage) {
         try {
-          state = JSON.parse(localStorage.getItem('replState'));
+          var storedState = localStorage.getItem('replState');
+          if (storedState) {
+            state = JSON.parse(storedState);  
+          }
         } catch(e) {}
     }
 


### PR DESCRIPTION
@thejameskyle This is a hotfix to the recent localstorage enhancement.  There is an issue when you first come into the REPL with a browser that supports local storage (i.e. it sets the state to null, then state.code throws).