### PR TITLE
parse help output

### DIFF
--- a/_help-output/insert-6to5-help-output.js
+++ b/_help-output/insert-6to5-help-output.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env 6to5-node
+
+import path from 'path';
+import fs from 'fs';
+import readHelp from './read-6to5-help';
+
+const BEGIN_MARKER = '// 6to5 Help Output > //';
+const END_MARKER = '// < 6to5 Help Output //';
+const INDENTATION = '  ';
+
+readHelp((err, output) => {
+  if (err) throw err;
+
+  insertHelpOutput(
+    JSON.stringify(output),
+    BEGIN_MARKER,
+    END_MARKER,
+    INDENTATION
+  );
+});
+
+function insertHelpOutput(helpOutput, beginMarker, endMarker, indentation = '') {
+  if (typeof process.argv[2] != 'string') {
+    throw new Error('Missing file path argument');
+  }
+
+  let filePath = path.resolve(process.cwd(), process.argv[2]);
+
+  if (!fs.statSync(filePath).isFile()) {
+    throw new Error(`File '${filePath}' does not exist`);
+  }
+
+  let content = fs.readFileSync(filePath).toString();
+
+  if (!(new RegExp(beginMarker)).test(content)) {
+    throw new Error(`Begin marker "${beginMarker}" not found in '${filePath}'`);
+  }
+
+  if (!(new RegExp(endMarker)).test(content)) {
+    throw new Error(`End marker "${endMarker}" not found in '${filePath}'`);
+  }
+
+  let replacement = [
+    beginMarker,
+    'var helpOutput = ' + helpOutput + ';',
+    endMarker
+  ].map((line, idx) => {
+    return idx === 0 ? line : (indentation + line);
+  }).join('\n');
+
+  content = content.replace(
+    new RegExp(`${beginMarker}\[\\s\\S\]*?${endMarker}`, 'm'),
+    replacement
+  );
+
+  console.info(`Replacing content in '${filePath}'...`);
+  fs.writeFileSync(filePath, content, 'utf8');
+  console.info(`File '${filePath}' updated`);
+}

--- a/_help-output/read-6to5-help.js
+++ b/_help-output/read-6to5-help.js
@@ -1,0 +1,88 @@
+import child_process from 'child_process';
+let exec = child_process.exec;
+
+const HELP_SECTION_NAMES = [
+  'usage',
+  'options',
+  'transformers',
+  'module formatters'
+];
+
+export default function readHelp(done) {
+  exec('6to5 --help', (err, stdout) => {
+    if (err) return done(err, null);
+
+    let parsedOutput;
+
+    try { parsedOutput = parseHelpOutput(stdout, HELP_SECTION_NAMES); }
+    catch (ex) { return done(ex, null); }
+
+    done(null, parsedOutput);
+  });
+}
+
+function parseHelpOutput(output, sectionNames) {
+  let parsed = {};
+  sectionNames.forEach(name => parsed[camelizeHelpSectionName(name)] = []);
+
+  let currSection = null;
+
+  output
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => !(/^\s*$/).test(line))
+    .forEach(line => {
+      let sectionName = getHelpSectionName(line, sectionNames);
+      if (sectionName) {
+        currSection = sectionName;
+        return;
+      }
+
+      if (currSection) {
+        parsed[camelizeHelpSectionName(currSection)]
+          .push(createHelpSectionEntry(line));
+      }
+    });
+
+  return parsed;
+}
+
+function getHelpSectionName(line, sectionNames) {
+  for (let i = 0, l = sectionNames.length; i < l; ++i) {
+    if ((new RegExp(`^${sectionNames[i]}:`, 'i')).test(line)) {
+      return sectionNames[i];
+    }
+  }
+}
+
+function camelizeHelpSectionName(sectionName) {
+  return sectionName.replace(/[-_\s]+(.)?/g, (match, c) => {
+    return c ? c.toUpperCase() : '';
+  });
+}
+
+function createHelpSectionEntry(line) {
+  line = line
+    .replace(/^-\s/, '')
+    .replace(/^-[a-zA-Z],\s/, '')
+    .replace(/^--/, '');
+
+  let lineParts = line.split(/\s{2,}/);
+  let entryParts = [...lineParts[0].split(' ')];
+  if (lineParts.length > 1) entryParts.push(lineParts[1]);
+
+  let tmpName = entryParts.shift();
+  let argName = entryParts.length > 1
+    ? entryParts.shift().replace(/^\[/, '').replace(/\]$/, '')
+    : null;
+  let desc = entryParts.length ? entryParts.shift() : null;
+  let name = tmpName.replace(/^\[/, '').replace(/\]$/, '');
+  let isOptional = name != tmpName;
+
+  let entry = { name };
+  if (argName) entry.argName = argName;
+  if (desc) entry.desc = desc;
+  if (isOptional) entry.isOptional = isOptional;
+
+  return entry;
+}

--- a/scripts/repl.js
+++ b/scripts/repl.js
@@ -1,5 +1,13 @@
 (function(to5, $, _, ace, window) {
 
+  // 6to5 Help Output > //
+  // < 6to5 Help Output //
+
+  var ignoredOptions = [
+    'help', 'source-maps-inline', 'source-maps', 'filename', 'watch',
+    'runtime', 'out-file', 'out-dir', 'include-regenerator', 'version'
+  ];
+
   /*
    * Utils for working with the browser's URI (e.g. the query params)
    */
@@ -15,7 +23,7 @@
 
   UriUtils.parseQuery = function () {
     var query = window.location.hash.replace(/^\#\?/, '');
-  
+
     return query.split('&').map(function(param) {
       var splitPoint = param.indexOf('=');
 
@@ -109,12 +117,12 @@
    */
   function REPL () {
     var state = UriUtils.parseQuery() || {};
-    
+
     if (window.localStorage) {
         try {
           var storedState = localStorage.getItem('replState');
           if (storedState) {
-            state = JSON.parse(storedState);  
+            state = JSON.parse(storedState);
           }
         } catch(e) {}
     }


### PR DESCRIPTION
issue #92 

Those two scripts are inserting a parsed output of `6to5 --help` inside a "target" file. The "target" must contain a begin and an end marker comment.

"read-6to5-help.js" returns the help output to json, so you can also get it with ajax, but because the docs are created with jekyll there is "insert-6to5-help-output.js" script which conforms to the static nature of the site.

The formatting of `6to5 --help` output must be consistent, but it's easy to make changes in "read-6to5-help.js" if needed.

"insert-6to5-help-output.js" must be executable and `6to5-node` must be in the system's path.

So you can add `./_help-output/insert-6to5-help-output.js ./scripts/repl.js` to the `Makefile`.
I added the begin/end marker comments to "./scripts/repl.js" along with an `ignoredOptions` array.

Then inside "./scripts/repl.js" -> `Options()` you can do something like this:
```javascript
var html = [];

for (var i = 0, l = helpOutput.options.length; i < l; ++i) {
  var option = helpOutput.options[i];
  if (~ignoredOptions.indexOf(option.name)) continue;
  
  html.push(...);
}
```

You can also create a backup of "./scripts/repl.js" before running "./_help-output/insert-6to5-help-output.js".


The json output of "read-6to5-help.js" is like this:
```javascript
{ usage: [],
  options:
   [ { name: 'help', desc: 'output usage information' },
     { name: 'source-maps-inline',
       desc: 'Append sourceMappingURL comment to bottom of code' },
     { name: 'source-maps',
       desc: 'Save source map alongside the compiled code' },
     { name: 'filename',
       argName: 'filename',
       desc: 'Filename to use when reading from stdin - this will be used in source-maps, errors etc [stdin]' },
     { name: 'watch', desc: 'Recompile files on changes' },
     { name: 'runtime',
       desc: 'Replace 6to5 declarations with references to a runtime' },
     { name: 'experimental',
       desc: 'Enable experimental support for proposed ES7 features' },
     { name: 'playground', desc: 'Enable playground support' },
     { name: 'modules',
       argName: 'modules',
       desc: 'Module formatter type to use [common]' },
     { name: 'whitelist',
       argName: 'whitelist',
       desc: 'Whitelist of transformers to ONLY use' },
     { name: 'blacklist',
       argName: 'blacklist',
       desc: 'Blacklist of transformers to NOT use' },
     { name: 'optional',
       argName: 'list',
       desc: 'List of optional transformers to enable' },
     { name: 'loose',
       argName: 'list',
       desc: 'List of transformers to enable their loose mode' },
     { name: 'out-file',
       argName: 'out',
       desc: 'Compile all input files into a single file' },
     { name: 'out-dir',
       argName: 'out',
       desc: 'Compile an input directory of modules into an output directory' },
     { name: 'remove-comments',
       desc: 'Remove comments from the compiled code' },
     { name: 'indent', argName: 'width', desc: 'Indent width [2]' },
     { name: 'amd-module-ids',
       desc: 'Insert module id in AMD modules' },
     { name: 'module-ids', desc: 'Insert module id in modules' },
     { name: 'react-compat',
       desc: 'Makes the react transformer produce pre-v0.12 code' },
     { name: 'include-regenerator',
       desc: 'Include the regenerator runtime if necessary' },
     { name: 'keep-module-id-extensions',
       desc: 'Keep extensions when generating module ids' },
     { name: 'version', desc: 'output the version number' } ],
  transformers:
   [ { name: 'abstractReferences' },
     { name: 'arrayComprehension' },
     { name: 'arrowFunctions' },
     { name: 'asyncToGenerator', isOptional: true },
     { name: 'blockScopingTDZ', isOptional: true },
     { name: 'bluebirdCoroutines', isOptional: true },
     { name: 'classes' },
     { name: 'computedPropertyNames' },
     { name: 'constants' },
     { name: 'coreAliasing', isOptional: true },
     { name: 'defaultParameters' },
     { name: 'destructuring' },
     { name: 'exponentiationOperator' },
     { name: 'forOf' },
     { name: 'generatorComprehension' },
     { name: 'generators' },
     { name: 'letScoping' },
     { name: 'malletOperator' },
     { name: 'memoizationOperator' },
     { name: 'methodBinding' },
     { name: 'modules' },
     { name: 'objectGetterMemoization' },
     { name: 'objectSpread' },
     { name: 'propertyMethodAssignment' },
     { name: 'propertyNameShorthand' },
     { name: 'protoToAssign', isOptional: true },
     { name: 'react' },
     { name: 'restParameters' },
     { name: 'specBlockScopedFunctions' },
     { name: 'specMemberExpressionLiterals' },
     { name: 'specNoForInOfAssignment' },
     { name: 'specPropertyLiterals' },
     { name: 'specSetters' },
     { name: 'spread' },
     { name: 'templateLiterals' },
     { name: 'typeofSymbol', isOptional: true },
     { name: 'undeclaredVariableCheck', isOptional: true },
     { name: 'undefinedToVoid', isOptional: true },
     { name: 'unicodeRegex' },
     { name: 'useStrict' } ],
  moduleFormatters:
   [ { name: 'amd' },
     { name: 'amdStrict' },
     { name: 'common' },
     { name: 'commonStrict' },
     { name: 'ignore' },
     { name: 'system' },
     { name: 'umd' },
     { name: 'umdStrict' } ] }
```
