### PR TITLE
Update examples

### DIFF
--- a/docs/learn-es6.md
+++ b/docs/learn-es6.md
@@ -615,33 +615,12 @@ c["key"] === undefined
 ### Subclassable Built-ins
 In ES6, built-ins like `Array`, `Date` and DOM `Element`s can be subclassed.
 
-Object construction for a function named `Ctor` now uses two-phases (both
-virtually dispatched):
-
-- Call `Ctor[@@create]` to allocate the object, installing any special behavior
-- Invoke constructor on new instance to initialize
-
-The known `@@create` symbol is available via `Symbol.create`. Built-ins now
-expose their `@@create` explicitly.
-
 ```js
-// Pseudo-code of Array
-class Array {
-    constructor(...args) { /* ... */ }
-    static [Symbol.create]() {
-        // Install special [[DefineOwnProperty]]
-        // to magically update "length"
-    }
-}
-
 // User code of Array subclass
 class MyArray extends Array {
     constructor(...args) { super(...args); }
 }
 
-// Two-phase "new":
-// 1) Call @@create to allocate object
-// 2) Invoke constructor on new instance
 var arr = new MyArray();
 arr[1] = 12;
 arr.length == 2
@@ -661,7 +640,7 @@ Math.acosh(3) // 1.762747174039086
 Math.hypot(3, 4) // 5
 Math.imul(Math.pow(2, 32) - 1, Math.pow(2, 32) - 2) // 2
 
-"abcde".contains("cd") // true
+"abcde".includes("cd") // true
 "abc".repeat(3) // "abcabcabc"
 
 Array.from(document.querySelectorAll("*")) // Returns a real Array
@@ -740,17 +719,18 @@ corresponding to the same meta-operations as the proxy traps. Especially useful
 for implementing proxies.
 
 ```js
-// No sample yet
-```
+var O = {a: 1};
+Object.defineProperty(O, 'b', {value: 2});
+O[Symbol('c')] = 3;
 
-<blockquote class="to5-callout to5-callout-danger">
-  <h4>Limited support from polyfill</h4>
-  <p>
-    Core.js only currently supports <code>Reflect.ownKeys</code>, if you would
-    like a much more complete Reflect API, include another polyfill such as
-    <a href="https://github.com/tvcutsem/harmony-reflect">Harmony Reflect</a>.
-  </p>
-</blockquote>
+Reflect.ownKeys(O); // ['a', 'b', Symbol(c)]
+
+function C(a, b){
+  this.c = a + b;
+}
+var instance = Reflect.construct(C, [20, 22]);
+instance.c; // 42
+```
 
 ### Tail Calls
 

--- a/docs/usage/transformers.md
+++ b/docs/usage/transformers.md
@@ -153,7 +153,7 @@ console.log(_core.$for.getIterator(arr));
 This means is that you can seamlessly use these native built-ins and static methods
 without worrying about where they come from.
 
-**NOTE:** Instance methods such as `"foobar".contains("foo")` will **not** work.
+**NOTE:** Instance methods such as `"foobar".includes("foo")` will **not** work.
 
 #### Helper aliasing
 


### PR DESCRIPTION
*  `.contains` -> `.includes`, [notes](https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-11/nov-18.md#51--44-arrayprototypecontains-and-stringprototypecontains), [draft](http://people.mozilla.org/~jorendorff/es6-draft.html#sec-string.prototype.includes)
* remove `@@create`, [notes](https://github.com/rwaldron/tc39-notes/blob/master/es6/2014-09/sept-24.md#object-instantiation-redo), [draft](http://wiki.ecmascript.org/doku.php?id=harmony:specification_drafts#october_14_2014_draft_rev_28)
* `Reflect` now avaliable