### PR TITLE
Add browser compatibility to the FAQ page.

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,6 +5,11 @@ description: Frequently Asked Questions and Answers
 permalink: /docs/faq/
 ---
 
+## What is the browser compatibility?
+
+As a rule of thumb, IE9+. You can support IE8 by limiting yourself to a subset of ES6 features. The
+[Caveats](/docs/usage/caveats) page goes into the details of supporting legacy browsers.
+
 ## How does 6to5 differ from other transpilers?
 
 Many issues plague current transpilers, 6to5 takes a unique approach to many aspects.


### PR DESCRIPTION
I would wager that this is **the** question people will be most interested in. As such, I've placed it at the top of the FAQ. If you think it'd be better placed somewhere else on the page, nbd, just lemme know and I can move it down.