### PR TITLE
Fix invalid link address in the doc/usage/require

### DIFF
--- a/docs/usage/require.md
+++ b/docs/usage/require.md
@@ -30,8 +30,7 @@ require("6to5/register");
 ```
 
 All subsequent files required by node with the extensions `.es6`, `.es`, `.jsx`
-and `.js` will be transformed by 6to5. The polyfill specified in
-[/docs/usage/polyfill](/docs/usage/polyfill) is also automatically required.
+and `.js` will be transformed by 6to5. The [polyfill](/docs/usage/polyfill) is also automatically required.
 
 **NOTE:** By default all requires to `node_modules` will be ignored. You can
 override this by passing an ignore regex via:

--- a/docs/usage/require.md
+++ b/docs/usage/require.md
@@ -31,7 +31,7 @@ require("6to5/register");
 
 All subsequent files required by node with the extensions `.es6`, `.es`, `.jsx`
 and `.js` will be transformed by 6to5. The polyfill specified in
-[/docs/usage/polyfill](polyfill) is also automatically required.
+[/docs/usage/polyfill](/docs/usage/polyfill) is also automatically required.
 
 **NOTE:** By default all requires to `node_modules` will be ignored. You can
 override this by passing an ignore regex via:


### PR DESCRIPTION
The origin code in the repo would create this link address: http://6to5.org/docs/usage/require/polyfill , and it's 404 page.

So the code in the `[]` should be `/docs/usage/polyfill` or `./polyfill` 