### PR TITLE
If you concatenate first, 6to5 won't duplicate code like _classCallCheck

### DIFF
--- a/docs/using-6to5.md
+++ b/docs/using-6to5.md
@@ -410,8 +410,8 @@ var concat = require("gulp-concat");
 gulp.task("default", function () {
   return gulp.src("src/**/*.js")
     .pipe(sourcemaps.init())
-    .pipe(to5())
     .pipe(concat("all.js"))
+    .pipe(to5())
     .pipe(sourcemaps.write("."))
     .pipe(gulp.dest("dist"));
 });


### PR DESCRIPTION
If you concatenate the code second, the code be like:

``` js
"use strict";

var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };

var Proxy = function Proxy() {
	_classCallCheck(this, Proxy);
};
"use strict";

var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };

var App = function App() {
	_classCallCheck(this, App);
};
```

But if you concatenate first, your code is all:

``` js
"use strict";

var _classCallCheck = function (instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } };

var Proxy = function Proxy() {
	_classCallCheck(this, Proxy);
};

var App = function App() {
	_classCallCheck(this, App);
};
```